### PR TITLE
Deque Axe Accessibility Scans Introduction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,5 +62,20 @@
             <artifactId>eyes-selenium-java5</artifactId>
             <version>RELEASE</version>
         </dependency>
+        <dependency>
+            <groupId>com.deque.html.axe-core</groupId>
+            <artifactId>selenium</artifactId>
+            <version>4.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.deque.html.axe-core</groupId>
+            <artifactId>dequeutilites</artifactId>
+            <version>4.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.18.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/modules/AxeAccessibilityModule.java
+++ b/src/main/java/modules/AxeAccessibilityModule.java
@@ -1,0 +1,16 @@
+package modules;
+
+import pages.AxeAccessibilityPage;
+
+public class AxeAccessibilityModule {
+    private final AxeAccessibilityPage axeAccessibilityPage;
+
+    public AxeAccessibilityModule(AxeAccessibilityPage axeAccessibilityPage) {
+        this.axeAccessibilityPage = axeAccessibilityPage;
+    }
+
+    public void scanCurrentPageForViolationsWithAxe() {
+        axeAccessibilityPage.scanCurrentPageForViolationsWithAxe();
+    }
+
+}

--- a/src/main/java/org/example/Formatters.java
+++ b/src/main/java/org/example/Formatters.java
@@ -1,0 +1,24 @@
+package org.example;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import java.io.File;
+import java.io.IOException;
+
+public class Formatters {
+
+    public void formatJson (String inputFile, String outputFile) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+            Object json = objectMapper.readValue(new File(inputFile), Object.class);
+            objectMapper.writeValue(new File(outputFile), json);
+            System.out.println("Formatted JSON saved as: " + outputFile);
+        } catch (IOException e) {
+            System.err.println("Error formatting JSON: " + e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/pages/AxeAccessibilityPage.java
+++ b/src/main/java/pages/AxeAccessibilityPage.java
@@ -1,0 +1,32 @@
+package pages;
+
+import com.deque.html.axecore.selenium.AxeBuilder;
+import com.deque.html.axecore.selenium.AxeReporter;
+import org.example.Formatters;
+import org.example.WebDriverFactory;
+import org.openqa.selenium.WebDriver;
+
+public class AxeAccessibilityPage {
+    private final WebDriver webDriver;
+    private final AxeBuilder axeBuilder;
+    private final Formatters formatters;
+
+    private static final String REPORT_DIR = "target/accessibility-reports/";
+    private static final String RAW_JSON_FILE = REPORT_DIR + ".json";
+    private static final String FORMATTED_JSON_FILE = REPORT_DIR + "formatted-axe-results.json";
+
+    public AxeAccessibilityPage() {
+        this.webDriver = WebDriverFactory.getWebDriver();
+        this.axeBuilder = new AxeBuilder();
+        this.formatters = new Formatters();
+    }
+
+    public void scanCurrentPageForViolationsWithAxe() {
+        AxeReporter.writeResultsToJsonFile(REPORT_DIR, axeBuilder.analyze(webDriver));
+        formatters.formatJson(RAW_JSON_FILE, FORMATTED_JSON_FILE);
+        // Currently the scan return a Json file in the automation project.
+        // There is no support by deque yet for a Java Json -> HTML report
+        // I will try to create a custom logic in a later phase for it, but for now its just Json ;p
+    }
+
+}

--- a/src/test/java/stepDefinitions/AxeAccessibilitySteps.java
+++ b/src/test/java/stepDefinitions/AxeAccessibilitySteps.java
@@ -1,0 +1,18 @@
+package stepDefinitions;
+
+import io.cucumber.java.en.Then;
+import modules.AxeAccessibilityModule;
+
+public class AxeAccessibilitySteps {
+    private final AxeAccessibilityModule axeAccessibilityModule;
+
+    public AxeAccessibilitySteps(AxeAccessibilityModule axeAccessibilityModule) {
+        this.axeAccessibilityModule = axeAccessibilityModule;
+    }
+
+    @Then("The user scans the current page for accessibility violations using Axe")
+    public void scanCurrentPageForViolationsWithAxe() {
+        axeAccessibilityModule.scanCurrentPageForViolationsWithAxe();
+    }
+
+}

--- a/src/test/resources/features/KristiniRegression.feature
+++ b/src/test/resources/features/KristiniRegression.feature
@@ -63,3 +63,15 @@ Feature: Automation Regression TCs for Kristini-BG
     Examples:
       | URL                     |
       | http://kristini-bg.com/ |
+
+  @TC-6
+  Scenario Outline: Contact Us Page - Page Accessibility Scan
+    Given The user navigates to "<URL>" URL
+    When The user navigates to "<Category>" from the Navigation Menu
+    Then Verify "<Category>" page is loaded
+    And Verify that the Contact Us form is loaded
+    And The user scans the current page for accessibility violations using Axe
+
+    Examples:
+      | URL                     | Category  |
+      | http://kristini-bg.com/ | Контакти  |


### PR DESCRIPTION
With this PR I am introducing automated accessibility page scans using Deque Axe tool.
- New Maven dependencies added for Deque and JsonFormatter.
- Introduced 3 new classes for the Axe Accessibility scans following POM.
- Introduced 1 new class "Formatter" which will hold different formatters (Json -> HTML) etc.
- Introduced JsonFormatter which format the Json to "RFC 8259" format, which will be used until formatter for Json -> HTML report is created.
- Introduced a new Gherkin TC that will use the new Axe Scan step.